### PR TITLE
Fix: NameError, python 3.6.2 (name long is not defined)

### DIFF
--- a/redisco/models/attributes.py
+++ b/redisco/models/attributes.py
@@ -7,7 +7,7 @@ import sys
 from functools import partial
 from datetime import datetime, date, timedelta
 from dateutil.tz import tzutc, tzlocal
-from six import string_types, text_type as unicode
+from six import string_types, integer_types, text_type as unicode
 from calendar import timegm
 from redisco.containers import List
 from .exceptions import FieldValidationError, MissingID
@@ -174,7 +174,7 @@ class IntegerField(Attribute):
         return int
 
     def acceptable_types(self):
-        return (int, long)
+        return integer_types
 
 
 class FloatField(Attribute):


### PR DESCRIPTION
Suggested changes will fix such errors:

```python 
Traceback (most recent call last):                                                                                                                     
  File "main.py", line 17, in <module>                                                                                                                                         
    obj.save()                                                                                                                                       
  File "/home/buran/envs/okapi/lib/python3.6/site-packages/redisco/models/base.py", line 339, in save                                                        
    if not self.is_valid():                                                                                                                     
  File "/home/buran/envs/okapi/lib/python3.6/site-packages/redisco/models/base.py", line 273, in is_valid                    
    field.validate(self)                                                                                                                               
  File "/home/buran/envs/okapi/lib/python3.6/site-packages/redisco/models/attributes.py", line 94, in validate                    
    if val is not None and not isinstance(val, self.acceptable_types()):                                                                        
  File "/home/buran/envs/okapi/lib/python3.6/site-packages/redisco/models/attributes.py", line 177, in acceptable_types          
    return (int, long)                                                                                                                                        
NameError: name 'long' is not defined                  
```

In Python 3, just int, so we should use `(int, )` instead of `(int, long)` in py3, please see https://pythonhosted.org/six/#six.integer_types 