### PR TITLE
Fix: NameError, python 3.6.2 (name basestring is not defined)

### DIFF
--- a/redisco/models/base.py
+++ b/redisco/models/base.py
@@ -2,7 +2,7 @@ import time
 from functools import partial
 from datetime import datetime, date
 from dateutil.tz import tzutc
-from six import with_metaclass
+from six import with_metaclass, string_types
 import redisco
 from redisco.containers import Set, List, SortedSet, NonPersistentList
 from .attributes import *
@@ -53,7 +53,7 @@ def _initialize_referenced(model_class, attribute):
                 .filter(**{attribute.attname: self.id}))
 
     klass = attribute._target_type
-    if isinstance(klass, basestring):
+    if isinstance(klass, string_types):
         return (klass, model_class, attribute)
     else:
         related_name = (attribute.related_name or


### PR DESCRIPTION
Suggested changes will fix such ReferenceField errors:

```python 
Traceback (most recent call last):                                                           
  File "main.py", line 2, in <module>                                                                                                                                                     
    import models                                                                            
  File "/home/buran/projects/okapi/src/models.py", line 57, in <module>                                                                                                 
    class Visit(models.Model):                
  File "/home/buran/envs/okapi/lib/python3.6/site-packages/redisco/models/base.py", line 220, in __init__
    deferred = _initialize_references(cls, name, bases, attrs)                                                                                                                            
  File "/home/buran/envs/okapi/lib/python3.6/site-packages/redisco/models/base.py", line 109, in _initialize_references
    refd = _initialize_referenced(model_class, v)                                            
  File "/home/buran/envs/okapi/lib/python3.6/site-packages/redisco/models/base.py", line 56, in _initialize_referenced                                                  
    if isinstance(klass, basestring):         
NameError: name 'basestring' is not defined    
```

Please see https://pythonhosted.org/six/#six.string_types